### PR TITLE
Leverage default sources support

### DIFF
--- a/pants-plugins/src/python/pants/contrib/thrifty/thrifty_library.py
+++ b/pants-plugins/src/python/pants/contrib/thrifty/thrifty_library.py
@@ -6,5 +6,4 @@ from pants.backend.jvm.targets.exportable_jvm_library import \
 
 
 class ThriftyLibrary(ExportableJvmLibrary):
-  def __init__(self, **kwargs):
-    super(ThriftyLibrary, self).__init__(**kwargs)
+  default_sources_globs = '*.thrift'


### PR DESCRIPTION
Not sure if you knew about this. If you grep for `default_sources_globs` in the pants codebase you'll find plenty of examples.