### PR TITLE
Leverage default sources support.

### DIFF
--- a/src/main/thrift/org/pantsbuild/contrib/thrifty/client/BUILD
+++ b/src/main/thrift/org/pantsbuild/contrib/thrifty/client/BUILD
@@ -2,5 +2,4 @@ thrifty_library(
     dependencies=[
         'src/main/thrift/org/pantsbuild/contrib/thrifty/common',
     ],
-    sources=globs('*.thrift'),
 )

--- a/src/main/thrift/org/pantsbuild/contrib/thrifty/common/BUILD
+++ b/src/main/thrift/org/pantsbuild/contrib/thrifty/common/BUILD
@@ -1,3 +1,1 @@
-thrifty_library(
-    sources=globs('*.thrift'),
-)
+thrifty_library()


### PR DESCRIPTION
Example `thrifty_library` targets no longer need to specify `sources`.